### PR TITLE
Fixes IME & text composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 !.mocharc.cjs
 lib
 cjs
+dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typewriter-editor",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typewriter-editor",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typewriter-editor",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A rich text editor using the Delta format with decorations and rendered with a tiny virtual dom",
   "keywords": [
     "typewriter",

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -68,6 +68,8 @@ export function setLineNodesRanges(editor: Editor) {
 
 
 export function render(editor: Editor, doc: TextDocument) {
+  // Don't render when actively composing
+  if (editor.modules.input?.isComposing) return;
   const { root } = editor;
   editor.dispatchEvent(new Event('rendering'));
   patch(root, renderDoc(editor, doc)) as HTMLElement;
@@ -78,6 +80,8 @@ export function render(editor: Editor, doc: TextDocument) {
 
 
 export function renderChanges(editor: Editor, oldDoc: TextDocument, newDoc: TextDocument) {
+  // Don't render when actively composing
+  if (editor.modules.input?.isComposing) return;
   const { root } = editor;
   // Ranges of line indexes, not document indexes
   const oldCombined = combineLines(editor, oldDoc.lines).combined;

--- a/src/rendering/selection.ts
+++ b/src/rendering/selection.ts
@@ -34,7 +34,8 @@ export function getSelection(editor: Editor): EditorRange | null {
  */
 export function setSelection(editor: Editor, range: EditorRange | null) {
   const { root } = editor;
-  if (!root.ownerDocument) return;
+  // Don't update selection when actively composing
+  if (!root.ownerDocument || editor.modules.input?.isComposing) return;
   const selection = root.ownerDocument.getSelection();
   if (!selection) return;
   const hasFocus = selection.anchorNode && root.contains(selection.anchorNode) && document.activeElement !== document.body;


### PR DESCRIPTION
The real problem we were having is that when the DOM or selection changed out from under an active composition, it would glitch and duplicate text and have other issues. This prevents any rendering/selection updates from occurring during text composition